### PR TITLE
Add JIT Docs pattern

### DIFF
--- a/documents/patterns/jit-docs.md
+++ b/documents/patterns/jit-docs.md
@@ -1,0 +1,53 @@
+---
+authors: [nitsan_avni]
+related_patterns:
+  - references
+  - knowledge-document
+related_obstacles:
+  - cannot-learn
+  - hallucinations
+---
+
+# JIT Docs
+
+## Pattern
+Rely on up-to-date documentation searched in real-time by the agent, rather than AI's outdated training data.
+
+**Workflow:**
+1. Point AI to documentation source once
+2. AI searches relevant sections in real-time based on your task
+3. AI fetches and uses current information
+4. One-click access via tools like Context7 MCP
+
+**Key shift:** From "AI knows from training" → "AI searches current docs"
+
+## Example
+
+**Building with Next.js 15:**
+Old way: AI uses outdated training data, suggests deprecated APIs
+New way: Point to Next.js docs once, AI searches current v15 docs for each feature you need
+
+**Using Context7:**
+```
+You: "Use context7 for Next.js, build auth flow"
+AI: Searches Next.js 15 docs in real-time
+AI: Finds current app router + middleware patterns
+AI: Generates code with actual current APIs
+```
+
+**Internal project patterns:**
+```
+You: "Check our API conventions doc"
+AI: Searches your docs for relevant patterns
+AI: Applies current team standards
+```
+
+**What this solves:**
+- Outdated training data → Current, accurate information
+- Hallucinated APIs → Real, version-specific docs
+- Manual doc hunting → Agent searches autonomously
+
+**Tools that enable this:**
+- Context7 MCP: One-click library documentation
+- Custom MCP servers: Project-specific docs
+- Agent search capabilities built into tools


### PR DESCRIPTION
## Summary
Add new pattern: **JIT Docs** (Just-in-Time Documentation) - describes workflow of relying on up-to-date documentation searched in real-time by the agent

## Description

The pattern captures a key workflow shift: instead of relying on AI's outdated training data, point AI to documentation sources and let it search current docs in real-time based on the task at hand.

**Workflow:**
1. Point AI to documentation source once
2. AI searches relevant sections in real-time
3. AI fetches and uses current information
4. One-click access via tools like Context7 MCP

**What this solves:**
- Outdated training data → Current, accurate information
- Hallucinated APIs → Real, version-specific docs
- Manual doc hunting → Agent searches autonomously

**Examples:**
- Context7 MCP for library docs (Next.js 15, etc.)
- Internal project documentation
- Version-specific API references

Related to:
- References (manual doc loading)
- Knowledge Document (persistent memory)

Addresses obstacles:
- Cannot Learn (no training on your code)
- Hallucinations (makes up APIs)

## Test plan
- [ ] Build passes: `cd website && npm run build`
- [ ] New pattern appears in the patterns list
- [ ] Author metadata displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)