### PR TITLE
Add Coerce to Interface pattern

### DIFF
--- a/documents/patterns/coerce-to-interface.md
+++ b/documents/patterns/coerce-to-interface.md
@@ -1,0 +1,43 @@
+---
+authors: [nitsan_avni]
+related_patterns:
+  - constrained-tests
+  - hooks
+  - ground-rules
+  - orchestrator
+---
+
+# Coerce to Interface
+
+## Context
+You're aiming for either a standardized way of doing something or a verified-to-work approach.
+
+## Pattern
+Design MCP tool interfaces that enforce structure through their API definition. Required fields, enums, and typed parameters become constraints the agent cannot bypass.
+
+The interface itself documents usage - well-named fields and clear types reduce the need for separate explanations.
+
+This shifts enforcement from instructions ("please include a title") to mechanism (the tool requires a `title` parameter).
+
+## Example
+
+**Learning MCP with constrained interface:**
+
+```typescript
+{
+  name: "add_learning",
+  parameters: {
+    filename: { type: "string", required: true },
+    title: { type: "string", required: true },
+    topic: { type: "string", required: true },
+    oneLiner: { type: "string", required: true },
+    context: { type: "string", required: true },
+    examples: { type: "string", required: true },
+    tags: { type: "array", items: { type: "string" } },
+    related: { type: "array", items: { type: "string" } }
+  }
+}
+```
+
+Every learning has identical anatomy. No variation possible. Results are immediately searchable by topic, filterable by tags, linkable through related fields.
+


### PR DESCRIPTION
## Summary
- Introduces the **Coerce to Interface** pattern for standardizing agent behavior through MCP tool interface design
- Uses required fields, enums, and typed parameters as constraints the agent cannot bypass
- Shifts enforcement from instructions to mechanism - interface design itself becomes the constraint

## Example
The pattern is demonstrated through a Learning MCP where the tool interface enforces identical anatomy for all learnings, making them immediately searchable, filterable, and linkable.

## Related Patterns
- Related to: constrained-tests, hooks, ground-rules, orchestrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)