### PR TITLE
Add 'Dementia' as alternate term for Context Rot

### DIFF
--- a/documents/obstacles/context-rot.md
+++ b/documents/obstacles/context-rot.md
@@ -1,8 +1,8 @@
 ---
-authors: [lada_kesseler]
+authors: [lada_kesseler, steve_kuo]
 ---
 
-# Context Rot (Obstacle)
+# Context Rot <Dementia> (Obstacle)
 
 ## Description
 Context degrades as the conversation grows. The model stops following earlier instructions, and performance drops unpredictably This happens long before you hit the context window limit.

--- a/documents/relationships.mmd
+++ b/documents/relationships.mmd
@@ -8,6 +8,7 @@ graph LR
   patterns/active-partner -->|solves| obstacles/compliance-bias
   patterns/active-partner -->|solves| obstacles/obedient-contractor
   patterns/canary-in-the-code-mine -->|solves| obstacles/degrades-under-complexity
+  patterns/canary-in-the-code-mine -->|solves| obstacles/context-rot
   patterns/chain-of-small-steps -->|solves| obstacles/degrades-under-complexity
   patterns/chain-of-small-steps -->|solves| obstacles/limited-focus
   patterns/check-alignment -->|solves| anti-patterns/silent-misalignment

--- a/website/config/authors.yaml
+++ b/website/config/authors.yaml
@@ -11,3 +11,6 @@ ivett_ordog:
 nitsan_avni:
   name: Nitsan Avni
   github: nitsanavni
+steve_kuo:
+  name: Steve Kuo
+  github: kuoman


### PR DESCRIPTION
## Summary
- Add Steve Kuo (@kuoman) as co-author of Context Rot obstacle
- Add "Dementia" as alternate terminology in title using `<Dementia>` format
- Connect Canary in Code Mine pattern as solution to detect Context Rot

## Context
"Dementia" is an intuitive term that captures the gradual forgetting aspect of context rot - when AI stops following rules/commands over time. The Canary in Code Mine pattern helps identify when this is happening by treating AI performance degradation as an early warning signal.

## Changes
- `documents/obstacles/context-rot.md`: Added co-author and alternate term
- `documents/relationships.mmd`: Added relationship showing Canary detects Context Rot  
- `website/config/authors.yaml`: Added steve_kuo author entry