### PR TITLE
fix(talk_path): fix broken link to the reference docs pattern

### DIFF
--- a/talk_path.md
+++ b/talk_path.md
@@ -16,7 +16,7 @@ Legend: ⛰ Obstacle | 🧩 Pattern | ⚠️ Anti-pattern
 - [⚠️ 5 Distracted Agent](documents/anti-patterns/distracted-agent.md)
 - [⛰️ Limited Focus](documents/obstacles/limited-focus.md)
 - [🧩 6 Focused Agent](documents/patterns/focused-agent.md)
-- [🧩 7 References](documents/patterns/references.md)
+- [🧩 7 References](documents/patterns/reference-docs.md)
 - [🧩 8 Knowledge Composition](documents/patterns/knowledge-composition.md)
 
 ### Noise


### PR DESCRIPTION
Updates the path for the "References" pattern in the `talk_path.md` file to point to the correct documentation. This ensures that users are directed to the intended `reference-docs.md` file instead of the previous `references.md` file which does not exist