### PR TITLE
Fix website font fallbacks

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -26,8 +26,10 @@
   --color-filter-unselected: #ffe3e3;
 
   /* Typography */
-  --font-sans: var(--font-geist-sans), system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
-  --font-mono: var(--font-geist-mono), 'SF Mono', Monaco, 'Cascadia Code', monospace;
+  --font-fallback: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono-fallback: "SF Mono", Monaco, "Cascadia Code", monospace;
+  --font-sans: var(--font-geist-sans, var(--font-fallback));
+  --font-mono: var(--font-geist-mono, var(--font-mono-fallback));
 
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;


### PR DESCRIPTION
The syntax for the CSS was not correct, so the fallbacks were not applied when `--font-geist-sans` is not defined. Can't define the fallbacks directly since CSS variables has fixed arity.

| Before | After |
| -- | -- |
| <img width="1437" height="1182" alt="Screenshot 2025-11-12 at 10 57 52" src="https://github.com/user-attachments/assets/b7fffdf8-48e2-4df2-a8e5-4c22cef34324" /> |  <img width="1559" height="1203" alt="Screenshot 2025-11-12 at 10 29 34" src="https://github.com/user-attachments/assets/9be3df3c-ad13-476a-a17d-c11751172ea3" /> |

Partial fix for #14. The "Geist" font is still not loading proper, why the font rendering ended up with the (undefined) fallback in the first place.
