### PR TITLE
Add Yak Shave Delegation pattern

### DIFF
--- a/documents/patterns/yak-shave-delegation.md
+++ b/documents/patterns/yak-shave-delegation.md
@@ -1,0 +1,27 @@
+---
+authors: [ivett_ordog]
+---
+
+# 🐃 Yak Shave Delegation
+
+## Problem
+
+Yak shaving breaks flow and context for both you and your primary agent. Environment issues derail focus even though they're often trivial to fix.
+
+## Pattern
+
+When a tangential issue blocks your main work, spawn a separate agent to handle it instead of switching context yourself.
+
+1. Hit an environment/tooling issue (compiler error, missing dependency, config problem)
+2. Recognize it's yak shaving - not your core task
+3. Spawn a separate agent to handle it (error messages usually contain the fix instructions)
+4. Continue your main work with your primary agent
+5. Check back when the yak-shave agent signals it's done
+
+This keeps both you and your main agent focused on the core problem while the yak shave gets resolved in parallel.
+
+## Example
+
+Returning to a project after some time, the codebase has moved on. Running the app fails - needs a new Ruby runtime, recompiled libraries, and config changes.
+
+Instead of context-switching to fix these, spawn an agent with the error output. The agent installs Ruby, recompiles dependencies, and updates config while you and your primary agent continue exploring the codebase and planning the next feature.

--- a/documents/relationships.mmd
+++ b/documents/relationships.mmd
@@ -82,6 +82,9 @@ graph LR
   patterns/happy-to-delete <-->|similar| patterns/playgrounds
   patterns/approved-fixtures <-->|similar| patterns/check-alignment
   patterns/approved-fixtures <-->|similar| patterns/approved-logs
+  patterns/yak-shave-delegation -->|uses| patterns/background-agent
+  patterns/yak-shave-delegation -->|uses| patterns/focused-agent
+  patterns/yak-shave-delegation -->|solves| anti-patterns/distracted-agent
 
   %% Anti-pattern → Obstacle relationships (causes)
   anti-patterns/distracted-agent -->|causes| obstacles/limited-focus


### PR DESCRIPTION
## Summary

- Adds new pattern: Yak Shave Delegation - spawn a separate agent for tangential environment/tooling issues instead of breaking flow
- A specific application of the Background Agent pattern focused on unplanned infrastructure distractions
- Adds relationships: uses background-agent, uses focused-agent, solves distracted-agent

## Test plan

- [x] `npm run validate` passes
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)