### PR TITLE
Add Decision Guards pattern

### DIFF
--- a/documents/patterns/decision-guards.md
+++ b/documents/patterns/decision-guards.md
@@ -1,0 +1,61 @@
+---
+authors: [svetkis]
+---
+
+# Decision Guards
+
+> A lightweight implementation of **ADR** (Architecture Decision Records), adapted for AI-assisted workflows. Instead of full decision documents, it uses inline markers that point to concise rationales in a decisions log.
+
+## Problem
+
+AI loves to refactor. It sees a synchronous function and thinks "this should be async." It spots a manual loop and wonders why you didn't use the library helper. The agent isn't wrong—locally, those look like improvements. But without knowing the history, it "fixes" code that was intentionally written that way, turning a careful tradeoff into a silent bug.
+
+`// don't touch this` doesn't work. The agent deletes it as noise. `AGENTS.md` helps, but that context degrades as the conversation grows.
+
+## Pattern
+
+Guard counter-intuitive code with a short numbered marker that points to a decisions file.
+
+Create `DECISIONS.md` with entries like:
+
+```markdown
+## DEC-42
+**Location**: `src/cache.ts:15`
+**Topic**: Intentionally sync cache lookup
+**Rationale**: Hot path (50k calls/min). Promise allocation adds 0.3ms. Deliberate performance tradeoff.
+```
+
+Inline reference:
+
+```typescript
+// DEC-42: sync lookup is intentional performance tradeoff
+function fastLookup(key: string): string {
+  return cache[key];
+}
+```
+
+Tell the agent in `AGENTS.md`: *If you see a `DEC-` comment, check `DECISIONS.md` before changing that code.*
+
+Don't mark everything. Reserve guards for code that looks wrong but isn't. If your decisions file grows faster than your codebase, the agent will start ignoring the markers.
+
+## Example
+
+**Without guard:** Agent refactors sync to async.
+
+```diff
+- function fastLookup(key: string): string {
+-   return cache[key];
+- }
++ async function fastLookup(key: string): Promise<string> {
++   return Promise.resolve(cache[key]);
++ }
+```
+
+**With guard:** Agent sees `DEC-42`, checks the decisions file, and leaves it alone.
+
+```typescript
+// DEC-42: sync lookup is intentional performance tradeoff
+function fastLookup(key: string): string {
+  return cache[key];
+}
+```

--- a/documents/relationships.mmd
+++ b/documents/relationships.mmd
@@ -79,6 +79,11 @@ graph LR
   patterns/habit-hooks -->|uses| patterns/contextual-prompts
   patterns/contextual-prompts -->|solves| obstacles/context-rot
   patterns/contextual-prompts -->|solves| obstacles/selective-hearing
+  patterns/decision-guards -->|solves| obstacles/obedient-contractor
+  patterns/decision-guards -->|solves| obstacles/context-rot
+  patterns/decision-guards -->|uses| patterns/knowledge-document
+  patterns/decision-guards -->|related| patterns/reminders
+  patterns/decision-guards -->|related| patterns/semantic-anchors
   patterns/contextual-prompts <-->|similar| patterns/reminders
   patterns/feedback-loop <-->|similar| patterns/playgrounds
   patterns/feedback-loop <-->|similar| patterns/chain-of-small-steps

--- a/website/config/authors.yaml
+++ b/website/config/authors.yaml
@@ -23,3 +23,6 @@ rdmueller:
 juan_michelini:
   name: Juan Michelini
   github: juanmichelini
+svetkis:
+  name: svetkis
+  github: svetkis


### PR DESCRIPTION
## Summary

Adds the **Decision Guards** pattern — a lightweight implementation of ADR (Architecture Decision Records), adapted for AI-assisted workflows.

## Problem it solves

AI agents love to refactor code that was intentionally written a certain way for performance, compatibility, or other trade-offs. Without knowing the history, the agent turns a careful decision into a silent bug.

## The pattern

Guard counter-intuitive code with short numbered markers () that point to a  file. The agent checks the rationale before changing anything.

## Files changed

-  — new pattern
-  — relationships to obstacles and other patterns
-  — author entry

**Author:** @svetkis