### PR TITLE
Add Escalate When Stuck pattern

### DIFF
--- a/documents/patterns/escalate-when-stuck.md
+++ b/documents/patterns/escalate-when-stuck.md
@@ -1,0 +1,28 @@
+---
+authors: [ivett_ordog]
+---
+
+# Escalate When Stuck
+
+## Problem
+Most of any task is routine work a cheap model handles fine. Occasionally it hits a wall: loops on a failing test, patches symptoms instead of causes, contradicts itself. Running the strongest model on the whole task to cover those rare moments is wasteful — but letting the cheap model thrash wastes even more (see Sunk Cost).
+
+## Pattern
+Default to the cheap model, and define escalation triggers:
+
+- Two failed attempts at the same problem
+- Reverting or contradicting its own changes
+- The agent declaring uncertainty
+
+On a trigger, consult the stronger model as an advisor: hand it the goal, the attempts so far, and the errors. The advisor diagnoses and plans; the cheap model resumes with the advice.
+
+Escalation can be automatic (instruct the agent to ask for help when stuck) or manual (you notice the thrashing and bring in the stronger model yourself).
+
+Same economics as a senior engineer on call: you don't have them type everything — you make them easy to ask.
+
+The complementary pattern is Smart Plan, Cheap Execution: there the smart model leads from the start; here it's only consulted when needed.
+
+## Example
+Sonnet implements a database migration. After the second failed attempt on the same failing test, it spawns a subagent on the strongest model with the diff, the error, and "what am I missing?" The advisor spots the wrong assumption — an ORM lifecycle detail — and Sonnet applies the correction and finishes.
+
+In Claude Code, subagents can run a different model than the main loop, so this works in both directions: a cheap main loop escalating to a smart subagent, or cheap workers under a smart orchestrator.

--- a/documents/relationships.mmd
+++ b/documents/relationships.mmd
@@ -68,6 +68,8 @@ graph LR
   patterns/context-management -->|uses| patterns/extract-knowledge
   patterns/context-management -->|uses| patterns/knowledge-checkpoint
   patterns/smart-plan-cheap-execution -->|uses| patterns/knowledge-checkpoint
+  patterns/escalate-when-stuck -->|solves| anti-patterns/sunk-cost
+  patterns/smart-plan-cheap-execution <-->|similar| patterns/escalate-when-stuck
   patterns/context-management -->|uses| patterns/focused-agent
   patterns/context-management -->|uses| patterns/semantic-zoom
   patterns/context-management -->|uses| patterns/noise-cancellation


### PR DESCRIPTION
The cheap model works by default and consults the strong model on defined triggers — two failed attempts, self-contradiction, declared uncertainty.

Based on `add-smart-plan-cheap-execution` rather than main: the two patterns are complements and share a `similar` edge, which needs both files present to validate.