### PR TITLE
Add Slice for Review pattern

### DIFF
--- a/documents/patterns/slice-for-review.md
+++ b/documents/patterns/slice-for-review.md
@@ -12,7 +12,7 @@ Let the agent deliver the large chunk — then add a splitting pass before human
 
 1. The agent finishes the large piece of work on a branch
 2. **Splitting pass**: the agent reorganizes the result into a stack of small, coherent, independently reviewable PRs — preparatory refactorings first, then behavior changes, then cleanups
-3. The same pass doubles as a cleanup pass: while reorganizing, the agent refactors and deletes cruft that turned out unnecessary
+3. The same pass doubles as a pruning pass: while reorganizing, the agent refactors and deletes cruft that turned out unnecessary
 4. Humans review the stack in order, each PR small enough to actually read
 
 You get agent-speed delivery and human-speed review without forcing either side to work at the other's pace.

--- a/documents/patterns/slice-for-review.md
+++ b/documents/patterns/slice-for-review.md
@@ -19,5 +19,3 @@ You get agent-speed delivery and human-speed review without forcing either side 
 
 ## Example
 An agent delivers a 3,000-line feature branch. The splitting pass produces five stacked PRs: two preparatory refactorings, the core feature, the API wiring, and test/documentation updates. Two abandoned experiments get deleted during the split. Each PR reviews in minutes.
-
-Teams adopting AI coding report this working well precisely because agents tend to deliver too much at once for humans to review — the splitting pass restores reviewability without slowing the agent down.

--- a/documents/patterns/slice-for-review.md
+++ b/documents/patterns/slice-for-review.md
@@ -1,0 +1,23 @@
+---
+authors: [ivett_ordog]
+---
+
+# Slice for Review
+
+## Problem
+Agents like to deliver more at once than a human can review. Big deliveries either stall in review or get rubber-stamped (see Flying Blind). But forcing the agent to work in tiny increments from the start sacrifices its throughput.
+
+## Pattern
+Let the agent deliver the large chunk — then add a splitting pass before human review:
+
+1. The agent finishes the large piece of work on a branch
+2. **Splitting pass**: the agent reorganizes the result into a stack of small, coherent, independently reviewable PRs — preparatory refactorings first, then behavior changes, then cleanups
+3. The same pass doubles as a cleanup pass: while reorganizing, the agent refactors and deletes cruft that turned out unnecessary
+4. Humans review the stack in order, each PR small enough to actually read
+
+You get agent-speed delivery and human-speed review without forcing either side to work at the other's pace.
+
+## Example
+An agent delivers a 3,000-line feature branch. The splitting pass produces five stacked PRs: two preparatory refactorings, the core feature, the API wiring, and test/documentation updates. Two abandoned experiments get deleted during the split. Each PR reviews in minutes.
+
+Teams adopting AI coding report this working well precisely because agents tend to deliver too much at once for humans to review — the splitting pass restores reviewability without slowing the agent down.

--- a/documents/relationships.mmd
+++ b/documents/relationships.mmd
@@ -54,6 +54,9 @@ graph LR
   patterns/active-partner -->|solves| anti-patterns/flying-blind
   patterns/feedback-loop -->|solves| anti-patterns/flying-blind
   patterns/constrained-tests -->|solves| anti-patterns/flying-blind
+  patterns/slice-for-review -->|solves| obstacles/keeping-up
+  patterns/slice-for-review -->|solves| anti-patterns/flying-blind
+  patterns/slice-for-review <-->|similar| patterns/chain-of-small-steps
   patterns/habit-hooks -->|solves| obstacles/cannot-learn
   patterns/habit-hooks -->|solves| obstacles/context-rot
   patterns/hooks -->|solves| obstacles/selective-hearing

--- a/documents/relationships.mmd
+++ b/documents/relationships.mmd
@@ -56,7 +56,6 @@ graph LR
   patterns/constrained-tests -->|solves| anti-patterns/flying-blind
   patterns/slice-for-review -->|solves| obstacles/keeping-up
   patterns/slice-for-review -->|solves| anti-patterns/flying-blind
-  patterns/slice-for-review <-->|similar| patterns/chain-of-small-steps
   patterns/habit-hooks -->|solves| obstacles/cannot-learn
   patterns/habit-hooks -->|solves| obstacles/context-rot
   patterns/hooks -->|solves| obstacles/selective-hearing


### PR DESCRIPTION
Let the agent deliver the large chunk at its own speed, then add a splitting pass that turns it into a stack of small, independently reviewable PRs.