### PR TITLE
Add Speak to Me pattern

### DIFF
--- a/documents/patterns/speak-to-me.md
+++ b/documents/patterns/speak-to-me.md
@@ -12,11 +12,7 @@ Ask the agent to speak short progress updates out loud as it works, using a text
 
 Voice becomes an ambient status channel: you follow the work without looking at it, and it claims your attention only when something actually needs it.
 
-Where Mind Dump uses voice as the input channel, Speak to Me uses it as the output channel.
-
 ## Example
-Add to the prompt or ground rules: "While working, announce your progress with the `say` command — one short sentence per milestone or blocker."
+Add to the prompt or ground rules: "While working on long tasks, use the `say` command to get my attention. Use it when you hit a blocker, change direction or reach a major milestone. Keep the announcements short, fewer than 10 words."
 
 You review another PR or cook dinner. In the background you hear: "Tests are green, starting the refactor." … "The migration is failing, I need your input." You come back exactly when you're needed — not before, not too late.
-
-A narrower variant appears in the Ground Rules example: "use ./speak.sh to talk to me out loud when you warn me about issues" — voice reserved for warnings only.

--- a/documents/patterns/speak-to-me.md
+++ b/documents/patterns/speak-to-me.md
@@ -1,0 +1,22 @@
+---
+authors: [ivett_ordog]
+---
+
+# Speak to Me
+
+## Problem
+You hand the agent a longer task and turn to something else. Watching the terminal defeats the purpose of delegating — but ignoring it means you discover problems late and miss the moments where a quick answer from you would unblock it.
+
+## Pattern
+Ask the agent to speak short progress updates out loud as it works, using a text-to-speech command (`say` on macOS). One short sentence per update: milestones reached, direction changes, blockers, questions for you.
+
+Voice becomes an ambient status channel: you follow the work without looking at it, and it claims your attention only when something actually needs it.
+
+Where Mind Dump uses voice as the input channel, Speak to Me uses it as the output channel.
+
+## Example
+Add to the prompt or ground rules: "While working, announce your progress with the `say` command — one short sentence per milestone or blocker."
+
+You review another PR or cook dinner. In the background you hear: "Tests are green, starting the refactor." … "The migration is failing, I need your input." You come back exactly when you're needed — not before, not too late.
+
+A narrower variant appears in the Ground Rules example: "use ./speak.sh to talk to me out loud when you warn me about issues" — voice reserved for warnings only.

--- a/documents/relationships.mmd
+++ b/documents/relationships.mmd
@@ -110,7 +110,6 @@ graph LR
   patterns/ai-first-responder -->|uses| patterns/background-agent
   patterns/ai-first-responder -->|uses| patterns/focused-agent
   patterns/ai-first-responder -->|uses| patterns/orchestrator
-  patterns/speak-to-me -->|extends| patterns/polyglot-ai
   patterns/speak-to-me -->|related| patterns/background-agent
 
   %% Anti-pattern → Obstacle relationships (causes)

--- a/documents/relationships.mmd
+++ b/documents/relationships.mmd
@@ -110,6 +110,8 @@ graph LR
   patterns/ai-first-responder -->|uses| patterns/background-agent
   patterns/ai-first-responder -->|uses| patterns/focused-agent
   patterns/ai-first-responder -->|uses| patterns/orchestrator
+  patterns/speak-to-me -->|extends| patterns/polyglot-ai
+  patterns/speak-to-me -->|related| patterns/background-agent
 
   %% Anti-pattern → Obstacle relationships (causes)
   anti-patterns/distracted-agent -->|causes| obstacles/limited-focus


### PR DESCRIPTION
Have the agent speak short progress updates out loud, so a long run becomes an ambient status channel instead of a terminal you have to watch.