### PR TITLE
Add a learning path through the pattern collection

### DIFF
--- a/documents/learning_path.html
+++ b/documents/learning_path.html
@@ -1,0 +1,447 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Augmented Coding Patterns — Learning Path</title>
+<style>
+  :root {
+    --ground: #f2f1ec;
+    --card: #ffffff;
+    --ink: #26282a;
+    --muted: #71746f;
+    --faint: #a3a49c;
+    --line: #c9c8bd;
+    --spine: #b4b3a6;
+    --pattern: #1e7a5a;
+    --pattern-soft: #e2f0ea;
+    --anti: #b0492d;
+    --anti-soft: #f6e6e0;
+    --obstacle: #4c617e;
+    --obstacle-soft: #e4e9f0;
+    --badge: #8a6d1f;
+    --badge-soft: #f3ecd6;
+    --card-border: #dddcd2;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ground: #17181a;
+      --card: #1f2124;
+      --ink: #e6e4dc;
+      --muted: #9b9e96;
+      --faint: #6a6d66;
+      --line: #35373a;
+      --spine: #4a4c48;
+      --pattern: #4fb890;
+      --pattern-soft: #1d3229;
+      --anti: #d97b5c;
+      --anti-soft: #38231b;
+      --obstacle: #8ba3c4;
+      --obstacle-soft: #232c39;
+      --badge: #cdb060;
+      --badge-soft: #322b16;
+      --card-border: #33363a;
+    }
+  }
+  :root[data-theme="dark"] {
+    --ground: #17181a; --card: #1f2124; --ink: #e6e4dc; --muted: #9b9e96;
+    --faint: #6a6d66; --line: #35373a; --spine: #4a4c48;
+    --pattern: #4fb890; --pattern-soft: #1d3229;
+    --anti: #d97b5c; --anti-soft: #38231b;
+    --obstacle: #8ba3c4; --obstacle-soft: #232c39;
+    --badge: #cdb060; --badge-soft: #322b16; --card-border: #33363a;
+  }
+  :root[data-theme="light"] {
+    --ground: #f2f1ec; --card: #ffffff; --ink: #26282a; --muted: #71746f;
+    --faint: #a3a49c; --line: #c9c8bd; --spine: #b4b3a6;
+    --pattern: #1e7a5a; --pattern-soft: #e2f0ea;
+    --anti: #b0492d; --anti-soft: #f6e6e0;
+    --obstacle: #4c617e; --obstacle-soft: #e4e9f0;
+    --badge: #8a6d1f; --badge-soft: #f3ecd6; --card-border: #dddcd2;
+  }
+
+  body {
+    background: var(--ground);
+    color: var(--ink);
+    font-family: "Avenir Next", "Avenir", "Segoe UI", system-ui, sans-serif;
+    line-height: 1.45;
+    margin: 0;
+    padding: 2.5rem 1.25rem 4rem;
+  }
+  .wrap { max-width: 860px; margin: 0 auto; }
+
+  /* ---------- header ---------- */
+  .masthead { margin-bottom: 1rem; }
+  .eyebrow {
+    font-size: .72rem; letter-spacing: .18em; text-transform: uppercase;
+    color: var(--muted); margin: 0 0 .5rem;
+  }
+  h1 {
+    font-family: "Futura", "Avenir Next", "Century Gothic", sans-serif;
+    font-size: clamp(1.7rem, 4.5vw, 2.5rem);
+    line-height: 1.12; margin: 0 0 .75rem; text-wrap: balance; font-weight: 600;
+  }
+  .thesis { max-width: 62ch; color: var(--muted); margin: 0 0 1.1rem; font-size: .98rem; }
+  .thesis strong { color: var(--ink); font-weight: 600; }
+  .facts { display: flex; flex-wrap: wrap; gap: .4rem .45rem; margin: 0 0 1.4rem; padding: 0; list-style: none; }
+  .facts li {
+    font-size: .78rem; padding: .22rem .6rem; border: 1px solid var(--line);
+    border-radius: 999px; color: var(--muted); background: var(--card);
+  }
+  .legend {
+    display: flex; flex-wrap: wrap; gap: .5rem 1.4rem; align-items: center;
+    border-top: 1px solid var(--line); border-bottom: 1px solid var(--line);
+    padding: .65rem 0; margin-bottom: 2.2rem; font-size: .8rem; color: var(--muted);
+  }
+  .legend span { display: inline-flex; align-items: center; gap: .45rem; }
+  .count { margin-left: auto; font-variant-numeric: tabular-nums; }
+
+  /* ---------- markers ---------- */
+  .mk { flex: 0 0 auto; width: 12px; height: 12px; display: inline-block; }
+  .mk-p { border-radius: 50%; background: var(--pattern); }
+  .mk-a { background: var(--anti); transform: rotate(45deg) scale(.85); }
+  .mk-o { background: var(--obstacle); clip-path: polygon(50% 0, 100% 100%, 0 100%); height: 11px; }
+
+  /* ---------- trail ---------- */
+  .trail { position: relative; padding-left: 44px; }
+  .trail::before {
+    content: ""; position: absolute; top: 8px; bottom: 8px; left: 13px;
+    width: 2px; background: var(--spine);
+  }
+  @media (max-width: 560px) { .trail { padding-left: 30px; } .trail::before { left: 6px; } }
+
+  .part { position: relative; margin: 2.6rem 0 1.3rem; display: flex; gap: 1rem; align-items: baseline; }
+  .part:first-child { margin-top: 0; }
+  .pno {
+    position: absolute; left: -44px; top: -2px; width: 28px; height: 28px;
+    background: var(--ink); color: var(--ground); border-radius: 6px;
+    display: flex; align-items: center; justify-content: center;
+    font-family: "Futura", "Avenir Next", sans-serif; font-size: .85rem; font-weight: 600;
+  }
+  @media (max-width: 560px) { .pno { left: -30px; width: 22px; height: 22px; font-size: .72rem; } }
+  .part h2 {
+    font-family: "Futura", "Avenir Next", "Century Gothic", sans-serif;
+    font-size: 1.35rem; font-weight: 600; margin: 0; letter-spacing: .01em;
+  }
+  .part p { margin: .15rem 0 0; color: var(--muted); font-size: .88rem; max-width: 58ch; }
+
+  .chapter { position: relative; margin-bottom: 1.4rem; }
+  .chapter::before {
+    content: ""; position: absolute; left: -37px; top: 14px; width: 12px; height: 12px;
+    border-radius: 50%; background: var(--ground); border: 3px solid var(--ink);
+  }
+  @media (max-width: 560px) { .chapter::before { left: -29px; width: 9px; height: 9px; border-width: 2.5px; } }
+
+  .card {
+    background: var(--card); border: 1px solid var(--card-border); border-radius: 10px;
+    padding: 1rem 1.15rem 1.05rem;
+  }
+  .ch-label {
+    font-size: .68rem; letter-spacing: .16em; text-transform: uppercase;
+    color: var(--faint); margin: 0 0 .1rem;
+  }
+  .card h3 { margin: 0 0 .25rem; font-size: 1.08rem; font-weight: 600; }
+  .lede { margin: 0 0 .75rem; color: var(--muted); font-size: .86rem; max-width: 60ch; }
+
+  .items { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: .32rem; }
+  .it { display: flex; align-items: baseline; gap: .55rem; font-size: .88rem; }
+  .it .mk { position: relative; top: 1px; }
+  .nm { font-weight: 600; white-space: nowrap; }
+  .it-o .nm { color: var(--obstacle); font-weight: 500; }
+  .it-a .nm { color: var(--anti); font-weight: 500; }
+  .nt { color: var(--muted); font-size: .82rem; }
+  .sub { padding-left: 1.35rem; }
+  .sub::before { content: "↳"; color: var(--faint); margin-right: -.1rem; }
+  .flag {
+    font-size: .68rem; padding: .1rem .45rem; border-radius: 999px;
+    background: var(--badge-soft); color: var(--badge); white-space: nowrap; font-weight: 600;
+  }
+
+  /* ---------- findings ---------- */
+  .findings { margin-top: 3rem; }
+  .findings h2 {
+    font-family: "Futura", "Avenir Next", "Century Gothic", sans-serif;
+    font-size: 1.2rem; font-weight: 600; margin: 0 0 .9rem;
+  }
+  .fgrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: .7rem; }
+  .fcard {
+    background: var(--card); border: 1px solid var(--card-border); border-radius: 10px;
+    padding: .85rem 1rem; font-size: .84rem;
+  }
+  .fcard h3 { margin: 0 0 .3rem; font-size: .88rem; font-weight: 600; }
+  .fcard p { margin: 0; color: var(--muted); }
+  .fcard .flag { display: inline-block; margin-bottom: .45rem; }
+
+  footer { margin-top: 2.4rem; font-size: .78rem; color: var(--faint); }
+</style>
+</head>
+<body>
+
+<div class="wrap">
+  <header class="masthead">
+    <p class="eyebrow">Augmented Coding Patterns · all 84 documents</p>
+    <h1>One trail through the whole collection</h1>
+    <p class="thesis">Your AI partner is brilliant and absurdly well-read — but it has <strong>no memory</strong>, <strong>limited attention</strong>, <strong>rolls dice on every answer</strong>, <strong>never says no</strong>, and <strong>you can't see what it's thinking</strong>. Every obstacle is one of these five facts showing up; every anti-pattern is a natural-but-wrong reaction; every pattern is the working counter-move.</p>
+    <ul class="facts">
+      <li>no memory → Part I</li>
+      <li>limited attention → Part I</li>
+      <li>dice-roll outputs → Part II</li>
+      <li>never says no → Part III</li>
+      <li>opaque → Part III</li>
+      <li>…then scale it → Part IV</li>
+    </ul>
+    <div class="legend">
+      <span><i class="mk mk-o"></i> obstacle — the terrain</span>
+      <span><i class="mk mk-a"></i> anti-pattern — the wrong turn</span>
+      <span><i class="mk mk-p"></i> pattern — the move</span>
+      <span>↳ special case / composition</span>
+      <span class="count">59 🧩 · 10 ⚠️ · 15 ⛰</span>
+    </div>
+  </header>
+
+  <div class="trail">
+
+    <header class="part"><span class="pno">I</span>
+      <div><h2>You Are Its Memory</h2>
+      <p>The machine cannot learn and forgets everything. Whatever should persist, you must externalize — then curate what little fits.</p></div>
+    </header>
+
+    <section class="chapter">
+      <div class="card">
+        <p class="ch-label">Chapter 1</p>
+        <h3>Manage the Context</h3>
+        <ul class="items">
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Cannot Learn</span><span class="nt">fixed weights, stateless — you are the memory</span></li>
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Limited Context Window</span><span class="nt">and the memory you manage is small</span></li>
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Context Rot</span><span class="nt">and it decays before it's full</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Context Management</span><span class="nt">the umbrella: you can only append or reset</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Knowledge Document</span><span class="nt">externalize to files — resets become cheap</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Ground Rules</span><span class="nt">knowledge document, always loaded</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Reference Docs</span><span class="nt">knowledge document, loaded on demand</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">JIT Docs</span><span class="nt">third policy: not stored — searched live</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Extract Knowledge</span><span class="nt">capture insights the moment they emerge</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Knowledge Composition</span><span class="nt">small, single-responsibility files</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <div class="card">
+        <p class="ch-label">Chapter 2</p>
+        <h3>Manage the Attention</h3>
+        <ul class="items">
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Limited Focus</span><span class="nt">attention dilutes or fixates</span></li>
+          <li class="it it-a"><i class="mk mk-a"></i><span class="nm">Distracted Agent</span><span class="nt">one agent for everything — rules silently ignored</span></li>
+          <li class="it it-a"><i class="mk mk-a"></i><span class="nm">Obsess Over Rules</span><span class="nt">more rules → each rule weaker</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Focused Agent</span><span class="nt">narrow responsibility wins</span></li>
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Excess Verbosity</span><span class="nt">it floods you by default</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Noise Cancellation</span><span class="nt">compress everything; fight bloat as hygiene</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Semantic Zoom</span><span class="nt">text is elastic — choose your abstraction level</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <header class="part"><span class="pno">II</span>
+      <div><h2>Trust Nothing, Verify Everything</h2>
+      <p>It fabricates confidently and rolls dice on every answer. Verify cheaply, checkpoint, reroll — and keep the task small enough to survive.</p></div>
+    </header>
+
+    <section class="chapter">
+      <div class="card">
+        <p class="ch-label">Chapter 3</p>
+        <h3>Close the Loop</h3>
+        <ul class="items">
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Hallucinations</span><span class="nt">invents APIs — mercifully self-revealing in code</span></li>
+          <li class="it it-a"><i class="mk mk-a"></i><span class="nm">Perfect Recall Fallacy</span><span class="nt">expecting it to remember library details</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Playgrounds</span><span class="nt">let it discover reality, not recall it</span></li>
+          <li class="it it-a"><i class="mk mk-a"></i><span class="nm">Unvalidated Leaps</span><span class="nt">every fix built on an unchecked assumption</span></li>
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Solution Fixation</span><span class="nt">first plausible hypothesis becomes “the answer”</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Feedback Loop</span><span class="nt">success signal + permission to iterate</span></li>
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Keeping Up</span><span class="nt">it generates faster than you can review</span></li>
+          <li class="it it-a"><i class="mk mk-a"></i><span class="nm">Flying Blind</span><span class="nt">the surrender: skip review, understand nothing</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Constrained Tests</span><span class="nt">tests designed so they can't be invalid</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Approved Scenarios</span><span class="nt">Constrained Tests, tuned for easy validation</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Approved Logs</span><span class="nt">Constrained Tests, tuned for bug reproduction</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Refinement Loop</span><span class="nt">one improvement goal per pass, until clean</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Feedback Flip</span><span class="nt">Refinement Loop with goal = critique</span><span class="flag">mark as special case</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <div class="card">
+        <p class="ch-label">Chapter 4</p>
+        <h3>Ride the Dice</h3>
+        <ul class="items">
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Non-Determinism</span><span class="nt">same prompt, different results</span></li>
+          <li class="it it-a"><i class="mk mk-a"></i><span class="nm">Sunk Cost</span><span class="nt">pushing iteration 5 when a fresh roll would win</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Knowledge Checkpoint</span><span class="nt">Extract Knowledge at the plan boundary — save plan, reroll code</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Happy to Delete</span><span class="nt">revert freely, keep the lesson</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Parallel Implementations</span><span class="nt">roll five dice, pick or combine the best</span><span class="flag">≈ Take All Paths</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Offload Deterministic</span><span class="nt">write the script once, run it forever</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <div class="card">
+        <p class="ch-label">Chapter 5</p>
+        <h3>Tame the Complexity</h3>
+        <ul class="items">
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Degrades Under Complexity</span><span class="nt">errors compound with step and artifact size</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Chain of Small Steps</span><span class="nt">small, verified, committed — you carry the complexity</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Canary in the Code Mine</span><span class="nt">AI struggling = your codebase asking for refactoring</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Surface Change Attractors</span><span class="nt">the same signal mined from history — hotspots and change coupling become redesign constraints</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <header class="part"><span class="pno">III</span>
+      <div><h2>Make It a Dialogue</h2>
+      <p>It's a black box trained to say yes. License the pushback, phrase to open the space, and meet it in its native medium.</p></div>
+    </header>
+
+    <section class="chapter">
+      <div class="card">
+        <p class="ch-label">Chapter 6</p>
+        <h3>Two-Way Alignment</h3>
+        <ul class="items">
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Black Box AI</span><span class="nt">you can't inspect its mental model</span></li>
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Compliance Bias</span><span class="nt">trained to comply over clarify</span></li>
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Obedient Contractor</span><span class="nt">literal, short-term, no pushback</span></li>
+          <li class="it it-a"><i class="mk mk-a"></i><span class="nm">Silent Misalignment</span><span class="nt">“sure thing, boss” while you talk past each other</span></li>
+          <li class="it it-a"><i class="mk mk-a"></i><span class="nm">Tell Me a Lie</span><span class="nt">your framing forces an answer that can't be true</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Active Partner</span><span class="nt">grant and reinforce permission to push back</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Check Alignment</span><span class="nt">it shows its understanding before implementing</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Context Markers</span><span class="nt">emoji make invisible context state visible</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Reverse Direction</span><span class="nt">break monologue inertia — flip who asks</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">You Do It</span><span class="nt">Reverse Direction for actions — “you do it”</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">ROSE Feedback</span><span class="nt">risk → observation → solution → expected outcome</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <div class="card">
+        <p class="ch-label">Chapter 7</p>
+        <h3>Speak Its Language</h3>
+        <ul class="items">
+          <li class="it it-a"><i class="mk mk-a"></i><span class="nm">Answer Injection</span><span class="nt">your question smuggles in the answer</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Cast Wide</span><span class="nt">the antidote — ask what you're not considering</span></li>
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Negative Bleedthrough</span><span class="nt">“no moon” puts the moon in the room</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Point the Target</span><span class="nt">say what you want, never what to avoid</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Semantic Anchors</span><span class="nt">one canonical term beats a paragraph</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <div class="card">
+        <p class="ch-label">Chapter 8</p>
+        <h3>Explore While It's Cheap</h3>
+        <ul class="items">
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Take All Paths</span><span class="nt">ten working prototypes, not one mockup</span><span class="flag">≈ Parallel Implementations</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Borrow Behaviors</span><span class="nt">the solution exists — transplant and adapt it</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Softest Prototype</span><span class="nt">markdown + AI is the system while you learn what you need</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <div class="card">
+        <p class="ch-label">Chapter 9</p>
+        <h3>Live in Text</h3>
+        <ul class="items">
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Text Native</span><span class="nt">if it can be text, make it text</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Diagrams as Code</span><span class="nt">extends Text Native to architecture docs</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Shared Canvas</span><span class="nt">Text Native as common ground for expert + dev + AI</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Polyglot AI</span><span class="nt">beyond text: voice and images, both directions</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Mind Dump</span><span class="nt">the voice channel, inbound — dump unfiltered, AI extracts signal</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Speak to Me</span><span class="nt">the voice channel, outbound — spoken one-line progress updates while you're elsewhere</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <header class="part"><span class="pno">IV</span>
+      <div><h2>From Sessions to Systems</h2>
+      <p>Instructions decay; mechanisms don't. Mechanize the enforcement, multiply the agents, close the meta-loop.</p></div>
+    </header>
+
+    <section class="chapter">
+      <div class="card">
+        <p class="ch-label">Chapter 10</p>
+        <h3>Make It Mechanical</h3>
+        <ul class="items">
+          <li class="it it-o"><i class="mk mk-o"></i><span class="nm">Selective Hearing</span><span class="nt">it filters your instructions by its priorities</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Hooks</span><span class="nt">the mechanism — deterministic lifecycle interception</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Reminders</span><span class="nt">TODOs, instruction sandwiches; User Reminders = Hooks re-injecting your rules</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Contextual Prompts</span><span class="nt">separate lever: guidance inside your own scripts' messages</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Habit Hooks</span><span class="nt">Contextual Prompts for tools you can't modify, via Hooks</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Coerce to Interface</span><span class="nt">typed interfaces make violations impossible</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <div class="card">
+        <p class="ch-label">Chapter 11</p>
+        <h3>Many Hands</h3>
+        <ul class="items">
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Chunking</span><span class="nt">orchestrator stays strategic, subagents execute</span><span class="flag">boundary unstated</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Background Agent</span><span class="nt">async agents for standalone tasks</span><span class="flag">boundary unstated</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Yak Shave Delegation</span><span class="nt">Background Agent for the blocking tangent</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Orchestrator</span><span class="nt">monitors, merges, keeps trunk green</span><span class="flag">boundary unstated</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Smart Plan, Cheap Execution</span><span class="nt">tier the models — the strongest plans, a cheaper one executes the spec</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Escalate When Stuck</span><span class="nt">reverse tiering — cheap by default, consult the strong model on triggers</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Phased Delivery</span><span class="nt">Background Agent with structure: plan → implement → review loop → rebase to atomic commits</span><span class="flag">name provisional</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Overnight Batch</span><span class="nt">issues batch-planned with deterministic gates, delivered unattended by a cloud agent</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Slice for Review</span><span class="nt">the agent splits a big delivery into stacked, reviewable PRs — shedding cruft as it goes</span><span class="flag">name provisional</span></li>
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">AI First Responder</span><span class="nt">capstone: Background Agent + Orchestrator + Focused Agent on incidents</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="chapter">
+      <div class="card">
+        <p class="ch-label">Chapter 12</p>
+        <h3>The System That Learns</h3>
+        <ul class="items">
+          <li class="it sub"><i class="mk mk-p"></i><span class="nm">Show the Agent, Let It Repeat, Automate</span><span class="nt">Extract Knowledge + Refinement Loop + Offload Deterministic as one lifecycle</span></li>
+          <li class="it"><i class="mk mk-p"></i><span class="nm">Learning Loop</span><span class="nt">every session ends with a learning pass, routed into ground rules, docs, habit hooks, or skills — a log surfaces recurring issues</span></li>
+          <li class="it it-a"><i class="mk mk-a"></i><span class="nm">AI Slop</span><span class="nt">the coda: no judgment added? don't hit publish</span></li>
+        </ul>
+      </div>
+    </section>
+
+  </div>
+
+  <section class="findings">
+    <h2>Consolidation findings</h2>
+    <div class="fgrid">
+      <div class="fcard">
+        <span class="flag">merge candidate</span>
+        <h3>Take All Paths ≈ Parallel Implementations</h3>
+        <p>The latter's “exploration mode” is Take All Paths, down to the examples. Merge, or split into economics vs mechanics.</p>
+      </div>
+      <div class="fcard">
+        <span class="flag">clarify boundaries</span>
+        <h3>Chunking / Background Agent / Orchestrator</h3>
+        <p>Three angles on boss-plus-workers: decompose one task / offload independent tasks / integrate results. Real boundaries, stated nowhere.</p>
+      </div>
+      <div class="fcard">
+        <span class="flag">mark special case</span>
+        <h3>Feedback Flip ⊂ Refinement Loop</h3>
+        <p>Refinement Loop says it verbatim. Make it structural, like Approved Scenarios/Logs already do with Constrained Tests.</p>
+      </div>
+      <div class="fcard">
+        <span class="flag">document distinctions</span>
+        <h3>The Hooks family</h3>
+        <p>Hooks = mechanism · User Reminders = one use of it · Contextual Prompts = separate concept (meaningful tool output) · Habit Hooks = Contextual Prompts for tools you can't modify. Distinct — but no doc says so.</p>
+      </div>
+    </div>
+  </section>
+
+  <footer>Companion to <code>documents/learning_path.md</code> · Lada's 27-station map survives intact as Chapters 1–7; post-talk additions extend the arc into Chapters 8–12.</footer>
+</div>
+</body>
+</html>

--- a/documents/learning_path.md
+++ b/documents/learning_path.md
@@ -1,0 +1,208 @@
+# A Learning Path Through the Augmented Coding Patterns
+
+*A proposed narrative organization of all 84 documents (59 patterns, 10 anti-patterns, 15 obstacles), with duplicate and special-case analysis. Extends Lada's 27-station semantic map to the full collection.*
+
+## The story in one paragraph
+
+You've been handed a brilliant, absurdly well-read colleague who has **no memory**, **limited attention**, **rolls dice on every answer**, **never says no**, and **you can't see what it's thinking**. The whole collection is the story of compensating for those five facts, in escalating scope: first you manage its *memory*, then its *attention*, then you learn to *verify* everything and even exploit the dice, then you turn the one-way command channel into a *dialogue*, meet it in its native *medium*, replace fragile instructions with *mechanisms*, and finally scale from one session to *systems of agents that improve themselves*. Every obstacle is one of the five facts showing up; every anti-pattern is a natural-but-wrong reaction to it; every pattern is the working counter-move.
+
+**Legend:** ⛰ obstacle (the terrain — can't be removed) · ⚠️ anti-pattern (the wrong turn) · 🧩 pattern (the move) · ↳ special case / composition marker
+
+---
+
+## Part I — You Are Its Memory
+
+### Chapter 1: Manage the Context
+*The machine cannot learn and forgets everything. Whatever should persist, you must externalize.*
+
+- ⛰ Cannot Learn — fixed weights, stateless; you are the memory
+- ⛰ Limited Context Window — the memory you manage is small
+- ⛰ Context Rot — and it decays long before it's full
+- 🧩 **Context Management** — the umbrella insight: context is a scarce, degrading resource; you can only append or reset
+- 🧩 **Knowledge Document** — the fundamental move: externalize knowledge to files so resets are cheap
+- 🧩 **Ground Rules** — ↳ knowledge documents on the *always-load* policy
+- 🧩 **Reference Docs** — ↳ knowledge documents on the *load-on-demand* policy
+- 🧩 **JIT Docs** — ↳ the third loading policy: don't store it at all, have the agent *search live external docs*
+- 🧩 **Extract Knowledge** — how documents get written: capture insights the moment they emerge
+- 🧩 **Knowledge Composition** — how documents stay loadable: small, single-responsibility files
+
+### Chapter 2: Manage the Attention
+*Even inside one session, everything competes for limited attention. Curate ruthlessly.*
+
+- ⛰ Limited Focus — attention dilutes or fixates
+- ⚠️ Distracted Agent — one agent for everything; rules silently ignored
+- ⚠️ Obsess Over Rules — piling on rules makes each one weaker
+- 🧩 **Focused Agent** — narrow responsibility; small focused agents beat large scattered ones
+- ⛰ Excess Verbosity — the machine floods you by default
+- 🧩 **Noise Cancellation** — compress responses and documents; fight bloat as hygiene
+- 🧩 **Semantic Zoom** — text is elastic: choose your abstraction level on demand (Noise Cancellation is the zoom-out half used as hygiene)
+
+---
+
+## Part II — Trust Nothing, Verify Everything
+
+### Chapter 3: Close the Loop
+*It fabricates confidently and declares victory early. Never let output go unverified — and make verification cheap enough that you don't skip it.*
+
+- ⛰ Hallucinations — it invents APIs (mercifully self-revealing in code)
+- ⚠️ Perfect Recall Fallacy — expecting it to remember library details from training
+- 🧩 **Playgrounds** — a sandbox where it discovers reality instead of recalling it
+- ⚠️ Unvalidated Leaps — chains of unverified assumptions; every fix builds on the broken one
+- ⛰ Solution Fixation — first plausible hypothesis becomes "the answer"
+- 🧩 **Feedback Loop** — give it a success signal and permission to iterate until green
+- ⛰ Keeping Up — it generates faster than you can review
+- ⚠️ Flying Blind — the surrender: skip review, vibe-code, understand nothing
+- 🧩 **Constrained Tests** — tests designed so they *can't* be invalid; coverage becomes trustworthy
+- 🧩 **Approved Scenarios** — ↳ special case of Constrained Tests, optimized for validation ease
+- 🧩 **Approved Logs** — ↳ special case of Constrained Tests, optimized for bug-reproduction speed
+- 🧩 **Feedback Flip** — ↳ special case of Refinement Loop: flip the same AI from producing to critiquing
+- 🧩 **Refinement Loop** — the general form: one improvement goal per pass, loop until nothing visible remains
+
+### Chapter 4: Ride the Dice
+*Output is a dice roll. Stop fighting that — checkpoint, reroll, and roll many dice at once.*
+
+- ⛰ Non-Determinism — same prompt, different results
+- ⚠️ Sunk Cost — pushing iteration 5 when a fresh roll would win
+- 🧩 **Knowledge Checkpoint** — ↳ Extract Knowledge at the plan/implementation boundary: protect expensive planning, make retries cheap
+- 🧩 **Happy to Delete** — AI code is disposable; revert freely, keep the lesson
+- 🧩 **Parallel Implementations** — roll five dice: parallel attempts from one checkpoint, pick or combine the best
+- 🧩 **Offload Deterministic** — dice have no place in deterministic work: have AI write a script once, run it forever
+
+### Chapter 5: Tame the Complexity
+*Reliability collapses as task and codebase complexity grow. Keep both small.*
+
+- ⛰ Degrades Under Complexity — errors compound with step size and artifact size
+- 🧩 **Chain of Small Steps** — small, verified, committed steps; complexity handled by you, not it
+- 🧩 **Canary in the Code Mine** — flip the signal: when the AI struggles, your *codebase* is telling you it needs refactoring
+- 🧩 **Surface Change Attractors** — the same signal, mined from history: hotspots and change coupling become the agent's redesign constraints
+
+---
+
+## Part III — Make It a Dialogue
+
+### Chapter 6: Two-Way Alignment
+*It's a black box trained to say yes. Alignment must be made visible and pushback must be licensed explicitly.*
+
+- ⛰ Black Box AI — you can't inspect its mental model
+- ⛰ Compliance Bias — trained to comply over clarify
+- ⛰ Obedient Contractor — one-day-contractor mindset: literal, short-term, no pushback
+- ⚠️ Silent Misalignment — "Sure thing, boss" while you talk past each other
+- ⚠️ Tell Me a Lie — your framing forces an answer that can't be true
+- 🧩 **Active Partner** — grant and reinforce permission to push back, question, disagree
+- 🧩 **Check Alignment** — make it show its understanding *before* implementation
+- 🧩 **Context Markers** — emoji signals make invisible context state visible at a glance
+- 🧩 **Reverse Direction** — break monologue inertia: flip who asks and who proposes
+- 🧩 **You Do It** — ↳ Reverse Direction for *actions*: "you do it" reveals capabilities neither side knew
+- 🧩 **ROSE Feedback** — feedback with risk/observation/solution/expected-outcome, so it fixes the principle, not the symptom
+
+### Chapter 7: Speak Its Language
+*What you say determines which concepts activate. Phrase to open the space, not close it.*
+
+- ⚠️ Answer Injection — your question smuggles in the answer and shrinks the solution space
+- 🧩 **Cast Wide** — the antidote: deliberately ask what you're *not* considering; push past your first framing
+- ⛰ Negative Bleedthrough — "don't mention the moon" puts the moon in the room
+- 🧩 **Point the Target** — describe what you want, never what to avoid
+- 🧩 **Semantic Anchors** — one canonical term ("TDD, London School", "arc42") beats a paragraph of description
+
+### Chapter 8: Explore While It's Cheap
+*Generation is nearly free. That changes how many ideas you can afford to try.*
+
+- 🧩 **Take All Paths** — build ten working prototypes, not one mockup *(see duplicate note: overlaps Parallel Implementations)*
+- 🧩 **Borrow Behaviors** — the solution exists somewhere; have AI transplant and adapt it
+- 🧩 **Softest Prototype** — softer than software: markdown instructions + AI *are* the system while you discover what you need
+
+### Chapter 9: Live in Text
+*Text is its native medium — and increasingly, everything else can be text too.*
+
+- 🧩 **Text Native** — if it can be text, make it text: designs, diagrams, plans, state
+- 🧩 **Diagrams as Code** — ↳ extends Text Native to architecture docs the agent can update in the same commit
+- 🧩 **Shared Canvas** — ↳ Text Native applied to collaboration: markdown as common ground for expert, developer, and AI
+- 🧩 **Polyglot AI** — beyond text: voice and images, both directions
+- 🧩 **Mind Dump** — ↳ Polyglot AI's voice channel, inbound: unfiltered stream of consciousness, AI extracts the signal
+- 🧩 **Speak to Me** — ↳ the voice channel, outbound: spoken one-line progress updates while you work on something else
+
+---
+
+## Part IV — From Sessions to Systems
+
+### Chapter 10: Make It Mechanical
+*Instructions decay; mechanisms don't. Move enforcement out of the context window.*
+
+- ⛰ Selective Hearing — it filters your instructions by *its* priorities; caps-lock won't save you
+- 🧩 **Hooks** — the mechanism: deterministic interception of the agent lifecycle — detect and correct instead of hoping
+- 🧩 **Reminders** — brute-force attention: TODOs, instruction sandwiches, and User Reminders (↳ Hooks used to re-inject your top rules)
+- 🧩 **Contextual Prompts** — a separate lever: meaningful guidance in your own scripts' error and success messages, surfacing exactly when relevant (works on humans too)
+- 🧩 **Habit Hooks** — ↳ Contextual Prompts applied to tools you can't modify (linters, quality detectors), delivered via Hooks: trigger → actionable coaching = habits for the AI
+- 🧩 **Coerce to Interface** — the strongest form: typed tool interfaces make violations *impossible*, not just detected
+
+### Chapter 11: Many Hands
+*One focused agent is good. Several, each focused, are better — if someone integrates.*
+
+- 🧩 **Chunking** — orchestrator stays strategic, subagents execute — like humans delegating practiced skills
+- 🧩 **Background Agent** — delegate standalone tasks to async agents while you stay on the main thread
+- 🧩 **Yak Shave Delegation** — ↳ Background Agent for the tangent that's blocking you
+- 🧩 **Orchestrator** — the integration agent: monitors, merges, resolves, keeps trunk green
+- 🧩 **Smart Plan, Cheap Execution** — tier the models: the strongest plans, a cheaper one executes the well-specified plan
+- 🧩 **Escalate When Stuck** — the reverse tiering: cheap by default, consult the strong model on defined triggers
+- 🧩 **Phased Delivery** — ↳ Background Agent with structure: plan → implement → review loop → rebase to atomic commits
+- 🧩 **Overnight Batch** — capture as issues, batch-plan with deterministic gates, cloud agent delivers unattended
+- 🧩 **Slice for Review** — after a big delivery, the agent splits it into stacked reviewable PRs (and sheds cruft doing it)
+- 🧩 **AI First Responder** — ↳ capstone composition (Background Agent + Orchestrator + Focused Agent) applied to incident response
+
+### Chapter 12: The System That Learns
+*The loop closes: sessions produce knowledge, knowledge produces automation, and you stay accountable for what ships.*
+
+- 🧩 **Show the Agent, Let It Repeat, Automate** — ↳ Extract Knowledge + Refinement Loop + Offload Deterministic as one lifecycle: collaborate once, document, refine, then automate away
+- 🧩 **Learning Loop** — the ritual version: every session ends with a learning pass that routes insights into ground rules, docs, habit hooks, or skills; a session log surfaces recurring issues
+- ⚠️ AI Slop — the closing warning: if you add no judgment and no context, don't hit publish. The whole path exists so that what you ship is *yours*.
+
+---
+
+## Duplicates and consolidation proposals
+
+### Strong — act on these
+
+1. **Take All Paths ≈ Parallel Implementations (exploration mode).** Parallel Implementations already contains an "Exploration of the Solution Space" mode with the same move and near-identical examples (N variations, combine the best, UI work). Take All Paths adds only the mindset framing ("prototyping is now free"). **Recommend: merge** — fold Take All Paths into Parallel Implementations as its motivation/exploration section, or explicitly split concerns: Take All Paths = *why/economics*, Parallel Implementations = *mechanics (checkpoint + worktrees)*. As two peer patterns they will keep confusing readers.
+
+2. **Chunking vs Orchestrator vs Background Agent.** Three views of the same architecture (boss agent + worker agents) by two authors, with no stated boundary. They *are* distinguishable — Chunking: decompose one task hierarchically, keep strategy up top; Background Agent: offload independent tasks async; Orchestrator: integrate the results — but no document says this. **Recommend: keep all three, add one "how these relate" paragraph to each** (or a tiny family intro). Also consider renaming Chunking (the psychology metaphor names the *analogy*, not the move; something like "Strategic Orchestrator" or "Delegate the Execution" says what to do).
+
+3. **Feedback Flip ⊂ Refinement Loop.** Refinement Loop says verbatim it's "like Feedback Flip, but generalized to any goal." **Recommend: mark Feedback Flip explicitly as a special case** (goal = critique), the way Approved Scenarios/Logs already declare Constrained Tests. Both can stay — the special case is the more actionable entry point.
+
+4. **Hooks / User Reminders / Contextual Prompts / Habit Hooks — not duplicates, but the boundaries are undocumented.** The actual taxonomy: Hooks is the *mechanism* (agent-lifecycle interception); User Reminders is one *use* of it (re-injecting your rules); Contextual Prompts is a *separate concept* — meaningful guidance in your own tools' output, predating AI; Habit Hooks *applies Contextual Prompts to tools you can't modify*, using Hooks for delivery (and exists as a standalone OSS product). None of the four documents states these boundaries — a careful reader still misfiles them as near-duplicates. **Recommend: add one boundary line to each doc** rather than any merge or umbrella.
+
+### Real special cases — make the relationship structural (`extends`)
+
+| Special case                  | General pattern                                                           | Status                                                                                    |
+|-------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| Approved Scenarios            | Constrained Tests                                                         | already stated in prose                                                                   |
+| Approved Logs                 | Constrained Tests                                                         | already stated in prose                                                                   |
+| Feedback Flip                 | Refinement Loop                                                           | stated only in Refinement Loop                                                            |
+| Yak Shave Delegation          | Background Agent                                                          | not stated                                                                                |
+| You Do It                     | Reverse Direction                                                         | mmd says "similar"; it's really RD applied to actions                                     |
+| Mind Dump                     | Polyglot AI                                                               | not stated                                                                                |
+| Shared Canvas                 | Text Native                                                               | not stated                                                                                |
+| Diagrams as Code              | Text Native                                                               | already `extends`                                                                         |
+| Knowledge Checkpoint          | Extract Knowledge                                                         | not stated                                                                                |
+| Ground Rules / Reference Docs | Knowledge Document                                                        | stated via `uses`; really two loading policies                                            |
+| Habit Hooks                   | Contextual Prompts (delivered via Hooks)                                  | mmd has `uses` edges; the "applies it to tools you can't modify" relationship is unstated |
+| User Reminders (in Reminders) | Hooks                                                                     | stated via example link only                                                              |
+| AI First Responder            | Background Agent + Orchestrator (composition)                             | stated via `uses`                                                                         |
+| Show the Agent…               | Extract Knowledge + Refinement Loop + Offload Deterministic (composition) | partially stated                                                                          |
+
+### Look-alikes that are genuinely different — one clarifying line each would help
+
+- **Cast Wide vs Reverse Direction** — widen the option space vs flip who's talking. Both say "show me approaches"; different problems (Answer Injection vs monologue inertia).
+- **Noise Cancellation vs Semantic Zoom** — hygiene (permanently remove bloat) vs navigation (temporarily change altitude).
+- **Playgrounds vs Softest Prototype** — sandbox to learn a library's reality vs markdown-as-the-product to learn your requirements.
+- **Feedback Loop vs Refinement Loop** — automated signal, iterate to *done* vs human-set goal, iterate to *better*.
+- **Extract Knowledge vs Knowledge Document** — the verb and the noun; fine as a pair, worth cross-linking tightly.
+
+### Coverage gaps in relationships.mmd (for whenever it's next touched)
+
+`cast-wide`, `borrow-behaviors`, `mind-dump`, `polyglot-ai`, `softest-prototype`, `shared-canvas`, `coerce-to-interface`, `jit-docs`, `feedback-flip`, and `ai-slop` have zero or no meaningful edges. Rather than adding more edges to an already unreadable graph, consider making **this path the primary navigation** and trimming the graph to just `extends` + `solves` edges — those two types carry nearly all the signal above.
+
+---
+
+## Coverage check
+
+All 59 patterns, 10 anti-patterns, and 15 obstacles appear exactly once above (pointer mentions aside). Lada's 27-station map survives intact: her Sections 1–3 map to Chapters 1–2, 3–5 (partially), and 6–7; the post-talk additions extend the same arc into Chapters 8–12 rather than disturbing it. The July 2026 additions (model tiering, autonomous delivery, Learning Loop, Surface Change Attractors) slot into Chapters 5, 11, and 12.


### PR DESCRIPTION
A narrative organization of the whole collection into 12 chapters, plus the duplicate/special-case analysis behind it. Extends Lada's 27-station semantic map to every document.

Two things to decide before this leaves draft:

- **The coverage claim is stale.** It says 84 documents (59 patterns). Current main has 54 patterns, and the eight pattern PRs bring it to 62 — so 87 documents. Decision Guards, External Context and Poor Person's Skill landed on main after this was written and do not appear anywhere in the path.
- **`learning_path.html`** is a rendered view of the same content. Nothing else in the repo ships a standalone HTML file, so it may not belong here — happy to drop it and keep only the markdown.

`learning_path_map.svg` is not included: it disappeared from the working tree before I could commit it.