### PR TITLE
Add Cognitive Overload anti-pattern

### DIFF
--- a/documents/anti-patterns/cognitive-overload.md
+++ b/documents/anti-patterns/cognitive-overload.md
@@ -1,0 +1,21 @@
+---
+authors: [aino_vonge_corry]
+---
+
+# Cognitive Overload (Anti-pattern)
+
+## Problem
+AI lowers the friction of starting new work, and most people prefer starting tasks over finishing them. Working on many things at once can even look impressive.
+
+## What Goes Wrong
+Many things start at once — branches, prototypes, experiments, tasks. You lose overview and get stressed. For the team it's worse: not only does everyone lose track of their own work, but what the team works on as a whole becomes overwhelming.
+
+**Consequences:** attention fragments, and the team loses a shared picture of what matters. It becomes hard to explain to other teams what you need and what you can offer.
+
+**Symptoms:** too many open loops, constant context switching, unfinished work.
+
+## Example
+This is a very human challenge, but AI makes it worse — it lowers the bar for starting a task even further. It shows up most in teams focused on working hard rather than doing things right.
+
+## Solution
+Limit work in progress. Finish, review, and learn before opening the next loop.

--- a/documents/relationships.mmd
+++ b/documents/relationships.mmd
@@ -128,6 +128,7 @@ graph LR
   %% Anti-pattern → Anti-pattern relationships (related)
   anti-patterns/sunk-cost -->|related| anti-patterns/answer-injection
   anti-patterns/sunk-cost -->|related| anti-patterns/tell-me-a-lie
+  anti-patterns/cognitive-overload -->|causes| anti-patterns/flying-blind
 
   %% Anti-pattern → Obstacle relationships (related/causes)
   anti-patterns/sunk-cost -->|related| obstacles/limited-context-window

--- a/website/config/authors.yaml
+++ b/website/config/authors.yaml
@@ -26,3 +26,6 @@ juan_michelini:
 svetkis:
   name: svetkis
   github: svetkis
+aino_vonge_corry:
+  name: Aino Vonge Corry
+  github: apaipi


### PR DESCRIPTION
## Summary
- Adds a new anti-pattern: **Cognitive Overload** — AI lowers the friction of starting new work, leading to too much WIP, fragmented attention, and a team losing its shared picture of what matters.
- Records `anti-patterns/cognitive-overload -->|causes| anti-patterns/flying-blind` in `documents/relationships.mmd`.
- Adds author entry for Aino Vonge Corry (`aino_vonge_corry`) in `website/config/authors.yaml`.

## Test plan
- [x] Ran the website locally (`npm run dev`) and viewed `/anti-patterns/cognitive-overload/` — renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)