### PR TITLE
Add Advisory Strategy and Smart Plan, Cheap Execution patterns

### DIFF
--- a/documents/patterns/advisory-strategy.md
+++ b/documents/patterns/advisory-strategy.md
@@ -1,0 +1,32 @@
+---
+authors: [ivett_ordog]
+---
+
+# Advisory Strategy
+
+Named after Anthropic's [advisor strategy](https://claude.com/blog/the-advisor-strategy).
+
+## Problem
+Most of a task is routine work a cheap model handles fine. Now and then it gets stuck: loops on a failing test, patches symptoms instead of causes, contradicts itself. Running the strongest model throughout to cover those few moments is expensive. Letting the cheap model thrash through them wastes more (see Sunk Cost).
+
+## Pattern
+Default to the cheap model and define escalation triggers:
+
+- Two failed attempts at the same problem
+- Reverting or contradicting its own changes
+- The agent declaring uncertainty
+
+On a trigger, consult the stronger model as an advisor: hand it the goal, the attempts so far, and the errors. The advisor diagnoses and plans; the cheap model resumes with the advice. The advisor writes no code and runs no tools, so its share of the bill stays small.
+
+Escalation can be automatic (instruct the agent to ask for help when stuck) or manual (you spot the thrashing and bring in the stronger model yourself).
+
+Same economics as a senior engineer on call. You don't have them type everything; you make them easy to ask.
+
+Anthropic's numbers: Sonnet 4.6 with an Opus advisor gained 2.7 points on SWE-bench Multilingual over Sonnet alone and cost 11.9% less per task, because an advisor's plan runs 400–700 tokens while the executor produces everything else at its own cheaper rate. Haiku 4.5 with the same advisor more than doubled its BrowseComp score, 19.7% to 41.2%. That still trails Sonnet working alone, but at 85% less cost per task.
+
+Smart Plan, Cheap Execution is the mirror image: the smart model leads from the start instead of waiting to be asked.
+
+## Example
+Sonnet implements a database migration. After the second failed attempt on the same test, it spawns a subagent on the strongest model with the diff, the error, and "what am I missing?" The advisor spots the wrong assumption, an ORM lifecycle detail, and Sonnet applies the correction and finishes.
+
+In Claude Code, subagents can run a different model than the main loop, so this works in both directions: a cheap main loop escalating to a smart subagent, or cheap workers under a smart orchestrator.

--- a/documents/patterns/smart-plan-cheap-execution.md
+++ b/documents/patterns/smart-plan-cheap-execution.md
@@ -1,0 +1,25 @@
+---
+authors: [ivett_ordog]
+---
+
+# Smart Plan, Cheap Execution
+
+## Problem
+The strongest models produce the best plans, and they are expensive and slow. Most implementation work doesn't need that much intelligence; it needs a good specification. Run everything on the strong model and you pay frontier prices for routine edits. Run everything on the cheap one and you get architectural mistakes that no amount of cheap iteration will fix.
+
+## Pattern
+Split the work by how much intelligence it actually needs:
+
+1. The strongest model plans: architecture, task breakdown, tricky decisions, acceptance criteria
+2. Save the plan to a document (see Knowledge Checkpoint), self-contained so the executor needs no other context
+3. A cheaper, faster model implements the plan step by step
+4. Return to the strong model when the plan itself needs to change, or for review
+
+Good planning turns an open-ended problem into a well-specified one, and well-specified tasks are what smaller models handle best.
+
+Advisory Strategy is the mirror image: the cheap model leads and asks for help instead of following a plan made for it. Anthropic's published numbers are for that version — Sonnet 4.6 with an Opus advisor gained 2.7 points on SWE-bench Multilingual and cost 11.9% less per task — and [the write-up](https://claude.com/blog/the-advisor-strategy) presents it as an inversion of the arrangement here, where the larger model decomposes the work and delegates it to smaller ones.
+
+## Example
+Claude Code's "opusplan" mode does exactly this: Opus runs plan mode, Sonnet executes the approved plan.
+
+The same idea works manually: plan a feature with the strongest model, checkpoint the plan to a file, then switch to a cheaper model for implementation. In multi-agent setups, run the orchestrator on the strong model and the worker subagents on cheaper ones.

--- a/documents/relationships.mmd
+++ b/documents/relationships.mmd
@@ -78,6 +78,9 @@ graph LR
   patterns/context-management -->|uses| patterns/knowledge-document
   patterns/context-management -->|uses| patterns/extract-knowledge
   patterns/context-management -->|uses| patterns/knowledge-checkpoint
+  patterns/smart-plan-cheap-execution -->|uses| patterns/knowledge-checkpoint
+  patterns/advisory-strategy -->|solves| anti-patterns/sunk-cost
+  patterns/smart-plan-cheap-execution <-->|similar| patterns/advisory-strategy
   patterns/context-management -->|uses| patterns/focused-agent
   patterns/context-management -->|uses| patterns/semantic-zoom
   patterns/context-management -->|uses| patterns/noise-cancellation


### PR DESCRIPTION
Two complementary patterns for splitting work between an expensive and a cheap model. They read as a pair and cross-reference each other, so they go in together.

**Advisory Strategy** — the cheap model runs by default and consults a stronger model as an advisor on defined triggers (two failed attempts, self-contradiction, declared uncertainty). The advisor writes no code and runs no tools, so its share of the bill stays small.

**Smart Plan, Cheap Execution** — the strong model plans, the plan is checkpointed to a document, a cheap model executes it step by step.

Advisory Strategy is named after Anthropic's [advisor strategy](https://claude.com/blog/the-advisor-strategy), which measured it: Sonnet 4.6 with an Opus advisor gained 2.7 points on SWE-bench Multilingual over Sonnet alone *and* cost 11.9% less per task; Haiku 4.5 more than doubled its BrowseComp score, 19.7% to 41.2%. The write-up presents the advisor arrangement as an inversion of plan-then-execute, so Smart Plan, Cheap Execution cites it as contrast rather than as evidence.

Replaces #43 and #44, which held the same two patterns on separate branches with an earlier draft of the text.

### Checks
`npm run validate`, `npm run lint`, 336 unit tests, and `npm run build` all pass. Both pages checked in the browser: headings, the Anthropic link, and the Related sidebar (similar-to / solves Sunk Cost) render correctly.
